### PR TITLE
Test/link helper

### DIFF
--- a/classes/LinkHelper.php
+++ b/classes/LinkHelper.php
@@ -89,6 +89,17 @@ class LinkHelper
      */
     private function getAttributes()
     {
+        $attributes = $this->getAttributesOutOfConfigs();
+
+        return new AttributeListHelper($attributes);
+    }
+
+    /**
+     * Returns an array of "real" attributes out of all configs
+     *
+     * @return array
+     */
+    private function getAttributesOutOfConfigs() {
         $falseAttributes = array('page', 'content');
         $attributes = array();
         foreach(array_keys($this->config) as $key) {
@@ -97,7 +108,7 @@ class LinkHelper
           }
         }
 
-        return new AttributeListHelper($attributes);
+        return $attributes;
     }
 
     /**

--- a/classes/LinkHelper.php
+++ b/classes/LinkHelper.php
@@ -89,16 +89,15 @@ class LinkHelper
      */
     private function getAttributes()
     {
-        return new AttributeListHelper(
-            array_filter(
-                $this->config,
-                function ($key) {
-                     return !in_array($key, array('page', 'content'));
-                },
-                ARRAY_FILTER_USE_KEY
-            )
-        );
+        $falseAttributes = array('page', 'content');
+        $attributes = array();
+        foreach(array_keys($this->config) as $key) {
+          if (!in_array($key, $falseAttributes)) {
+            $attributes[$key] = $this->config[$key];
+          }
+        }
 
+        return new AttributeListHelper($attributes);
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
   "require-dev": {
-    "codeception/codeception": "2.2.*"
+    "codeception/codeception": "2.2.*",
+    "getgrav/grav": "*"
   }
 }

--- a/tests/unit/LinkHelperTest.php
+++ b/tests/unit/LinkHelperTest.php
@@ -2,13 +2,13 @@
 
 use Grav\Plugin\LinkToTwigExtension\LinkHelper;
 use \Codeception\Util\Stub;
-use Grav\Common\Page\Page;
 
 class LinkHelperTest extends \Codeception\Test\Unit
 {
 
     public function testLinkCreationFromPageObject()
     {
-        // Tests will be added here as soon as I find how to mock page objects.
+      $page = Stub::make('Grav\Common\Page\Page', ['link' => 'http://www.example.com/',  'menu' => 'Example.com']);
+      $this->assertEquals('<a href="http://www.example.com/">Example.com</a>', new LinkHelper($page));
     }
 }


### PR DESCRIPTION
Test that LinkHelper can output a link out of a Grav\Common\Page\Page object.

A compatibility issue with PHP 5.5.9 has been resolved.